### PR TITLE
update the base query to only show deals that expire in the future

### DIFF
--- a/src/Deals.php
+++ b/src/Deals.php
@@ -83,6 +83,7 @@ class Deals
 	public function getBaseQuery($limit = false, $offset = 0)
 	{
 		$query = DB::table('deals')
+					->where('dtEndDate','>=',date('Y-m-d H:i:s'))
 					->orderBy('fRating', 'desc');
 
 		if ($limit !== false) {


### PR DESCRIPTION
I verified that this worked by manually updating a deal in the database to be expired. The deal no longer appeared on the index page.
