### PR TITLE
Add dtStartDate condition to the getBaseQuery function

### DIFF
--- a/src/Deals.php
+++ b/src/Deals.php
@@ -114,6 +114,7 @@ class Deals
 		$query = DB::table('deals')
 					->select(DB::raw('fmtc_merchants.*, fmtc_deals.*'))
 					->join('merchants', 'deals.nMerchantID', '=', 'merchants.nMerchantID')
+					->where('dtStartDate', '<=', date('Y-m-d H:i:s'))
 					->where('dtEndDate', '>=', date('Y-m-d H:i:s'));
 		
 		if($starred) {


### PR DESCRIPTION
We weren't querying on the begin date at all. I added the missing condition.
