### PR TITLE
Extend the cCode field from varchar(8) to varchar(100)

### DIFF
--- a/src/Migration.php
+++ b/src/Migration.php
@@ -62,7 +62,7 @@ class Migration
 				$table->string('cLabel', 250);
 				$table->string('cImage', 88);
 				$table->string('cRestrictions', 100);
-				$table->string('cCode', 8);
+				$table->string('cCode', 100);
 				$table->string('dtStartDate', 25);
 				$table->string('dtEndDate', 25);
 				$table->string('cLastUpdated', 25);


### PR DESCRIPTION
The 8 is far too short.  E.g. we have codes like "RESTAURANT20" that are being truncated to "RESTAURA".
